### PR TITLE
batcher: short-circuit when timeout is 0

### DIFF
--- a/batcher/batcher_test.go
+++ b/batcher/batcher_test.go
@@ -32,6 +32,13 @@ func TestBatcherSuccess(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+
+	b = New(0, returnsSuccess)
+	for i := 0; i < 10; i++ {
+		if err := b.Run(nil); err != nil {
+			t.Error(err)
+		}
+	}
 }
 
 func TestBatcherError(t *testing.T) {


### PR DESCRIPTION
There's no point in launching a goroutine and setting a timer and all that junk,
just run the work function inline.

Also clarify that the work function must be concurrency-safe, since that is now
much more obviously true. It was always true, but you could be forgiven for
concluding the opposite on a quick skim of the old code.