### PR TITLE
Spelling fix: aquire -> acquire

### DIFF
--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -8,7 +8,7 @@ import (
 
 // ErrNoTickets is the error returned by Acquire when it could not acquire
 // a ticket from the semaphore within the configured timeout.
-var ErrNoTickets = errors.New("could not aquire semaphore ticket")
+var ErrNoTickets = errors.New("could not acquire semaphore ticket")
 
 // Semaphore implements the semaphore resiliency pattern
 type Semaphore struct {


### PR DESCRIPTION
This is to increase the report card score for avelino/awesome-go#1448 so I can add this to the awesome Go list.

Go report card: https://goreportcard.com/report/github.com/eapache/go-resiliency