### PR TITLE
Semaphore empty check added

### DIFF
--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -43,3 +43,8 @@ func (s *Semaphore) Acquire() error {
 func (s *Semaphore) Release() {
 	<-s.sem
 }
+
+// IsEmpty would return true if none acquired ar that moment of time, otherwise false.
+func (s *Semaphore) IsEmpty() bool {
+	return len(s.sem) == 0
+}

--- a/semaphore/semaphore_test.go
+++ b/semaphore/semaphore_test.go
@@ -45,6 +45,26 @@ func TestSemaphoreBlockTimeout(t *testing.T) {
 	}
 }
 
+func TestSemaphoreEmpty(t *testing.T) {
+	sem := New(2, 200*time.Millisecond)
+
+	if !sem.IsEmpty() {
+		t.Error("semaphore should be empty")
+	}
+
+	sem.Acquire()
+
+	if sem.IsEmpty() {
+		t.Error("semaphore should not be empty")
+	}
+
+	sem.Release()
+
+	if !sem.IsEmpty() {
+		t.Error("semaphore should be empty")
+	}
+}
+
 func ExampleSemaphore() {
 	sem := New(3, 1*time.Second)
 


### PR DESCRIPTION
While shutting down an application using semaphore, it's better to check if the semaphore is fully released. The empty check feature helps in ensuring the same.