### PR TITLE
Fix goroutine leak in deadline

### DIFF
--- a/deadline/deadline.go
+++ b/deadline/deadline.go
@@ -32,7 +32,11 @@ func (d *Deadline) Run(work func(<-chan struct{}) error) error {
 	stopper := make(chan struct{})
 
 	go func() {
-		result <- work(stopper)
+		value := work(stopper)
+		select {
+		case result <- value:
+		case <-stopper:
+		}
 	}()
 
 	select {


### PR DESCRIPTION
If the deadline timed out then the worker goroutine might have been
leaked trying to write to `result` which had no readers.

Fixes #23.

@evolsnow please let me know if you see any issues with this fix.