### PR TITLE
Implements error unwrapping for error checking

### DIFF
--- a/retrier/classifier.go
+++ b/retrier/classifier.go
@@ -1,5 +1,7 @@
 package retrier
 
+import "errors"
+
 // Action is the type returned by a Classifier to indicate how the Retrier should proceed.
 type Action int
 
@@ -38,7 +40,7 @@ func (list WhitelistClassifier) Classify(err error) Action {
 	}
 
 	for _, pass := range list {
-		if err == pass {
+		if errors.Is(err, pass) {
 			return Retry
 		}
 	}
@@ -57,7 +59,7 @@ func (list BlacklistClassifier) Classify(err error) Action {
 	}
 
 	for _, pass := range list {
-		if err == pass {
+		if errors.Is(err, pass) {
 			return Fail
 		}
 	}


### PR DESCRIPTION
Issue related to #28

Note: this might need further consideration, since `errors.Is` was added on Go 1.13, which might be a breaking change for clients.

I have considered other alternative like using optional parameters & build constraints so this will only be compiled for the correct Go version, but that requires much bigger changes.