### PR TITLE
Add LimitedExponentialBackoff

### DIFF
--- a/retrier/backoffs.go
+++ b/retrier/backoffs.go
@@ -22,3 +22,20 @@ func ExponentialBackoff(n int, initialAmount time.Duration) []time.Duration {
 	}
 	return ret
 }
+
+// LimitedExponentialBackoff generates a simple back-off strategy of retrying 'n' times, and doubling the amount of
+// time waited after each one.
+// If back-off reaches `limitAmount` , thereafter back-off will be filled with `limitAmount` .
+func LimitedExponentialBackoff(n int, initialAmount time.Duration, limitAmount time.Duration) []time.Duration {
+	ret := make([]time.Duration, n)
+	next := initialAmount
+	for i := range ret {
+		if next < limitAmount {
+			ret[i] = next
+			next *= 2
+		} else {
+			ret[i] = limitAmount
+		}
+	}
+	return ret
+}

--- a/retrier/backoffs_test.go
+++ b/retrier/backoffs_test.go
@@ -53,3 +53,33 @@ func TestExponentialBackoff(t *testing.T) {
 		t.Error("incorrect value")
 	}
 }
+
+func TestLimitedExponentialBackoff(t *testing.T) {
+	b := LimitedExponentialBackoff(1, 10*time.Millisecond, 11*time.Millisecond)
+	if len(b) != 1 {
+		t.Error("incorrect length")
+	}
+	if b[0] != 10*time.Millisecond {
+		t.Error("incorrect value")
+	}
+
+	b = LimitedExponentialBackoff(5, 1*time.Minute, 4*time.Minute)
+	if len(b) != 5 {
+		t.Error("incorrect length")
+	}
+	if b[0] != 1*time.Minute {
+		t.Error("incorrect value")
+	}
+	if b[1] != 2*time.Minute {
+		t.Error("incorrect value")
+	}
+	if b[2] != 4*time.Minute {
+		t.Error("incorrect value")
+	}
+	if b[3] != 4*time.Minute {
+		t.Error("incorrect value")
+	}
+	if b[4] != 4*time.Minute {
+		t.Error("incorrect value")
+	}
+}


### PR DESCRIPTION
@eapache 
Thank you very much for this project.

Currently, there is no upper limit for `ExponentialBackoff` .
Therefore, n (number of times) needs to be set so that 2^n is an appropriate value for a back-off.

However, there are some use-cases where we want to limit the maximum back-off while ensuring a sufficient number of retries.
`LimitedExponentialBackoff` has been added to handle such use-case.

So, there are two changes.

* Add LimitedExponentialBackoff 
* Add tests for LimitedExponentialBackoff