### PR TITLE
Improved memory consumption on timeout checks

### DIFF
--- a/deadline/deadline.go
+++ b/deadline/deadline.go
@@ -39,10 +39,15 @@ func (d *Deadline) Run(work func(<-chan struct{}) error) error {
 		}
 	}()
 
+	timer := time.NewTimer(d.timeout)
 	select {
 	case ret := <-result:
+		if !timer.Stop() {
+			<-timer.C
+		}
+
 		return ret
-	case <-time.After(d.timeout):
+	case <-timer.C:
 		close(stopper)
 		return ErrTimedOut
 	}

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -29,10 +29,15 @@ func New(tickets int, timeout time.Duration) *Semaphore {
 // If it cannot after "timeout" amount of time, it returns ErrNoTickets. It is
 // safe to call Acquire concurrently on a single Semaphore.
 func (s *Semaphore) Acquire() error {
+	timer := time.NewTimer(s.timeout)
 	select {
 	case s.sem <- struct{}{}:
+		if !timer.Stop() {
+			<-timer.C
+		}
+
 		return nil
-	case <-time.After(s.timeout):
+	case <-timer.C:
 		return ErrNoTickets
 	}
 }


### PR DESCRIPTION
This PR prevents memory leaks by time.After usage.

Closes https://github.com/eapache/go-resiliency/issues/36