### PR TITLE
feat: implement WithInfiniteRetry() option

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/maximebeckman/go-resiliency
+module github.com/eapache/go-resiliency
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/eapache/go-resiliency
+module github.com/maximebeckman/go-resiliency
 
 go 1.13

--- a/retrier/retrier.go
+++ b/retrier/retrier.go
@@ -11,11 +11,12 @@ import (
 // Retrier implements the "retriable" resiliency pattern, abstracting out the process of retrying a failed action
 // a certain number of times with an optional back-off between each retry.
 type Retrier struct {
-	backoff []time.Duration
-	class   Classifier
-	jitter  float64
-	rand    *rand.Rand
-	randMu  sync.Mutex
+	backoff       []time.Duration
+	infiniteRetry bool
+	class         Classifier
+	jitter        float64
+	rand          *rand.Rand
+	randMu        sync.Mutex
 }
 
 // New constructs a Retrier with the given backoff pattern and classifier. The length of the backoff pattern
@@ -34,9 +35,15 @@ func New(backoff []time.Duration, class Classifier) *Retrier {
 	}
 }
 
+// WithInfiniteRetry set the retrier to loop infinitely on the last backoff duration
+func (r *Retrier) WithInfiniteRetry() *Retrier {
+	r.infiniteRetry = true
+	return r
+}
+
 // Run executes the given work function by executing RunCtx without context.Context.
 func (r *Retrier) Run(work func() error) error {
-	return r.RunCtx(context.Background(), func(ctx context.Context) error {
+	return r.RunCtx(context.Background(), func(ctx context.Context, retries int) error {
 		// never use ctx
 		return work()
 	})
@@ -47,16 +54,16 @@ func (r *Retrier) Run(work func() error) error {
 // returned to the caller. If the result is Retry, then Run sleeps according to the its backoff policy
 // before retrying. If the total number of retries is exceeded then the return value of the work function
 // is returned to the caller regardless.
-func (r *Retrier) RunCtx(ctx context.Context, work func(ctx context.Context) error) error {
+func (r *Retrier) RunCtx(ctx context.Context, work func(ctx context.Context, retries int) error) error {
 	retries := 0
 	for {
-		ret := work(ctx)
+		ret := work(ctx, retries)
 
 		switch r.class.Classify(ret) {
 		case Succeed, Fail:
 			return ret
 		case Retry:
-			if retries >= len(r.backoff) {
+			if !r.infiniteRetry && retries >= len(r.backoff) {
 				return ret
 			}
 
@@ -84,6 +91,9 @@ func (r *Retrier) sleep(ctx context.Context, timer *time.Timer) error {
 }
 
 func (r *Retrier) calcSleep(i int) time.Duration {
+	if i >= len(r.backoff) {
+		i = len(r.backoff) - 1
+	}
 	// lock unsafe rand prng
 	r.randMu.Lock()
 	defer r.randMu.Unlock()

--- a/retrier/retrier.go
+++ b/retrier/retrier.go
@@ -35,7 +35,9 @@ func New(backoff []time.Duration, class Classifier) *Retrier {
 	}
 }
 
-// WithInfiniteRetry set the retrier to loop infinitely on the last backoff duration
+// WithInfiniteRetry set the retrier to loop infinitely on the last backoff duration. Using this option,
+// the program will not exit until the retried function has been executed successfully.
+// WARNING : This may run indefinitely.
 func (r *Retrier) WithInfiniteRetry() *Retrier {
 	r.infiniteRetry = true
 	return r


### PR DESCRIPTION
Hi,
First of all, thank you very much for this library that I'm using.
I'm submitting this pull request to you, which adds a feature I need in some of my projects, namely the ability to retry indefinitely.
Due to transactional constraints, in some cases, I cannot afford for a transaction not to be executed, and I believe that using your retrier coupled with good monitoring should handle the job more cleanly than a panicOnError().

That's why the request includes the following modifications:
- Offer the possibility to retry indefinitely with the last backoff duration set
- Works with any backoff duration strategy
- Add a 'retries' parameters to the function passed into RunCtx() args, so that the called function know the number of current retries