### PR TITLE
Simplify timer cleanup

### DIFF
--- a/deadline/deadline.go
+++ b/deadline/deadline.go
@@ -42,10 +42,7 @@ func (d *Deadline) Run(work func(<-chan struct{}) error) error {
 	timer := time.NewTimer(d.timeout)
 	select {
 	case ret := <-result:
-		if !timer.Stop() {
-			<-timer.C
-		}
-
+		timer.Stop()
 		return ret
 	case <-timer.C:
 		close(stopper)

--- a/retrier/retrier.go
+++ b/retrier/retrier.go
@@ -96,10 +96,7 @@ func (r *Retrier) sleep(ctx context.Context, timer *time.Timer) error {
 	case <-timer.C:
 		return nil
 	case <-ctx.Done():
-		if !timer.Stop() {
-			<-timer.C
-		}
-
+		timer.Stop()
 		return ctx.Err()
 	}
 }

--- a/semaphore/semaphore.go
+++ b/semaphore/semaphore.go
@@ -32,10 +32,7 @@ func (s *Semaphore) Acquire() error {
 	timer := time.NewTimer(s.timeout)
 	select {
 	case s.sem <- struct{}{}:
-		if !timer.Stop() {
-			<-timer.C
-		}
-
+		timer.Stop()
 		return nil
 	case <-timer.C:
 		return ErrNoTickets


### PR DESCRIPTION
The timer channels are created with a buffer. Because we aren't reusing them, we don't need to worry about draining that channel; the internal goroutine will still be able to write to the buffer and exit gracefully, at which point the GC will clean it all up.

We *do* still need to call `Stop()` to tell the timer to clean up immediately, as otherwise it will run for its full duration which (in a tight loop) can cause timer goroutines to pile up.

@rjeczalik I still think this is just a minor simplification that won't have any noticeable performance impact, but you were right in #41 that draining the channel is technically unnecessary.

cc @dnozdrin as you reported the initial memory issue with the timer goroutines piling up; as far as I can tell this should still be safe in that regard