### PR TITLE
Add go 1.22 to CI

### DIFF
--- a/.github/workflows/golang-ci.yml
+++ b/.github/workflows/golang-ci.yml
@@ -7,7 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.13, 1.18]
+        go-version:
+          - 1.13
+          - 1.18
+          - 1.22
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
It's the latest version, several years newer than the version we were previously testing, and I expect it to be the one shipped with the next Ubuntu LTS so it's a good one to test. Keep 1.18 around as it's the version shipped with the *previous* Ubuntu LTS and so is worth testing as long as it's supported.

Supersedes #48 which reminded me that CI versions was out of date.