### PR TITLE
Add a SurfaceWorkErrors() opt to the retrier

### DIFF
--- a/retrier/retrier.go
+++ b/retrier/retrier.go
@@ -44,7 +44,7 @@ func (r *Retrier) WithInfiniteRetry() *Retrier {
 	return r
 }
 
-// WithSurfaceWorkErrors configures the retrier to always return the last non-nil error received from work()
+// WithSurfaceWorkErrors configures the retrier to always return the last error received from work function
 // even if a context timeout/deadline is hit.
 func (r *Retrier) WithSurfaceWorkErrors() *Retrier {
 	r.surfaceWorkErrors = true
@@ -91,7 +91,7 @@ func (r *Retrier) RunFn(ctx context.Context, work func(ctx context.Context, retr
 
 			timer := time.NewTimer(r.calcSleep(retries))
 			if err := r.sleep(ctx, timer); err != nil {
-				if r.surfaceWorkErrors && ret != nil {
+				if r.surfaceWorkErrors {
 					return ret
 				}
 				return err

--- a/retrier/retrier.go
+++ b/retrier/retrier.go
@@ -11,12 +11,13 @@ import (
 // Retrier implements the "retriable" resiliency pattern, abstracting out the process of retrying a failed action
 // a certain number of times with an optional back-off between each retry.
 type Retrier struct {
-	backoff       []time.Duration
-	infiniteRetry bool
-	class         Classifier
-	jitter        float64
-	rand          *rand.Rand
-	randMu        sync.Mutex
+	backoff           []time.Duration
+	infiniteRetry     bool
+	surfaceWorkErrors bool
+	class             Classifier
+	jitter            float64
+	rand              *rand.Rand
+	randMu            sync.Mutex
 }
 
 // New constructs a Retrier with the given backoff pattern and classifier. The length of the backoff pattern
@@ -40,6 +41,13 @@ func New(backoff []time.Duration, class Classifier) *Retrier {
 // WARNING : This may run indefinitely.
 func (r *Retrier) WithInfiniteRetry() *Retrier {
 	r.infiniteRetry = true
+	return r
+}
+
+// WithSurfaceWorkErrors configures the retrier to always return the last non-nil error received from work()
+// even if a context timeout/deadline is hit.
+func (r *Retrier) WithSurfaceWorkErrors() *Retrier {
+	r.surfaceWorkErrors = true
 	return r
 }
 
@@ -83,6 +91,9 @@ func (r *Retrier) RunFn(ctx context.Context, work func(ctx context.Context, retr
 
 			timer := time.NewTimer(r.calcSleep(retries))
 			if err := r.sleep(ctx, timer); err != nil {
+				if r.surfaceWorkErrors && ret != nil {
+					return ret
+				}
 				return err
 			}
 

--- a/retrier/retrier_test.go
+++ b/retrier/retrier_test.go
@@ -153,40 +153,48 @@ func TestRetrierRunFnWithInfinite(t *testing.T) {
 	}
 }
 
-func TestRetrierCtxSurfaceWorkErrors(t *testing.T) {
-	// Will timeout before getting to errBar.
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Millisecond)
-	defer cancel()
-	r := New([]time.Duration{0, 10 * time.Millisecond}, nil).WithSurfaceWorkErrors()
-	errExpected := []error{errFoo, errFoo, errBar, errBaz}
-	retries := 0
-	err := r.RunCtx(ctx, func(ctx context.Context) error {
-		if retries >= len(errExpected) {
-			return nil
-		}
-		err := errExpected[retries]
-		retries++
-		return err
-	})
-	if err != errFoo {
-		t.Error(err)
-	}
-}
-
 func TestRetrierRunFnWithSurfaceWorkErrors(t *testing.T) {
-	// Will timeout before getting to errBar.
-	ctx, cancel := context.WithTimeout(context.Background(), 7*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	r := New([]time.Duration{0, 10 * time.Millisecond}, nil).WithSurfaceWorkErrors()
-	errExpected := []error{errFoo, errFoo, errFoo, errBar, errBaz}
+	errExpected := []error{errFoo, errBar, errBaz}
 
 	err := r.RunFn(ctx, func(ctx context.Context, retries int) error {
 		if retries >= len(errExpected) {
 			return nil
 		}
-		return errExpected[retries]
+		if retries == 1 {
+			// Context canceled inside second call to work function.
+			cancel()
+		}
+		err := errExpected[retries]
+		retries++
+		return err
 	})
-	if err != errFoo {
+	if err != errBar {
+		t.Error(err)
+	}
+}
+
+func TestRetrierRunFnWithoutSurfaceWorkErrors(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	r := New([]time.Duration{0, 10 * time.Millisecond}, nil)
+	errExpected := []error{errFoo, errBar, errBaz}
+
+	err := r.RunFn(ctx, func(ctx context.Context, retries int) error {
+		if retries >= len(errExpected) {
+			return nil
+		}
+		if retries == 1 {
+			// Context canceled inside second call to work function.
+			cancel()
+		}
+		err := errExpected[retries]
+		retries++
+		return err
+	})
+	if err != context.Canceled {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
If the retrier encounters a context-related error, such as `context.DeadlineExceeded` while attempting retries of `work()`, the context error is returned. This means the actual error from `work()` never bubbles up. Because the context is often used to enforce a timeout, many callers are likely more interested in the last non-nil error returned by the `work()` function.

We introduce a `WithSurfaceWorkErrors()` option to the `retrier.Retrier` that when used, means the last non-nil `work` error will be returned even if context-related errors are encountered.