### PR TITLE
feat: add dynamic backoff

### DIFF
--- a/retrier/classifier_test.go
+++ b/retrier/classifier_test.go
@@ -34,7 +34,7 @@ type wrappedErr struct {
 }
 
 func (w wrappedErr) Error() string {
-	return "there's an error happening during X: " + w.Error()
+	return "there's an error happening during X: " + w.error.Error()
 }
 
 func (w wrappedErr) Unwrap() error {

--- a/retrier/errors.go
+++ b/retrier/errors.go
@@ -1,0 +1,19 @@
+package retrier
+
+import "time"
+
+type errWithBackoff struct {
+	err     error
+	backoff time.Duration
+}
+
+func ErrWithBackoff(err error, backoff time.Duration) error {
+	return &errWithBackoff{
+		err:     err,
+		backoff: backoff,
+	}
+}
+
+func (e *errWithBackoff) Error() string {
+	return e.err.Error()
+}

--- a/retrier/retrier_test.go
+++ b/retrier/retrier_test.go
@@ -153,6 +153,24 @@ func TestRetrierRunFnWithInfinite(t *testing.T) {
 	}
 }
 
+func TestRetrierWithDynamicBackoff(t *testing.T) {
+	r := New([]time.Duration{0, 10 * time.Millisecond}, nil)
+	st := time.Now()
+
+	err := r.Run(genWork([]error{ErrWithBackoff(errFoo, 500*time.Millisecond)}))
+	if err != nil {
+		t.Error(err)
+	}
+	if i != 2 {
+		t.Error("run wrong number of times")
+	}
+
+	if time.Since(st) < 500*time.Millisecond {
+		t.Error("not wait dynamic backoff")
+	}
+
+}
+
 func TestRetrierRunFnWithSurfaceWorkErrors(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()


### PR DESCRIPTION
Hi,  
First of all, thank you for this excellent library! It has been incredibly useful in my projects.  

I’m submitting this pull request to add a feature that enables dynamic backoff support. In some cases, the called service may return a [`Retry-After`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After) header and expects us to wait for the specified time before retrying. However, this header is not always present. Additionally, there are scenarios where I’d like to set a zero backoff for certain errors, allowing an immediate retry.  

This pull request introduces the following modifications:  
- Added a new error constructor, `ErrWithBackoff`, to specify dynamic backoff durations.  
- Updated `RunFn` to handle `ErrWithBackoff` by dynamically setting the backoff duration based on the error field.  
- Added a test to verify the dynamic backoff logic.  

I believe this feature will make the library more flexible and useful in various retry scenarios.  
Thank you for considering this contribution!  